### PR TITLE
feat: conditionally include expo-dev-client for EAS builds only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,4 +39,12 @@ TypeScript 5.x: Follow standard conventions
 - 002-skills-dev-methodology: Added Markdown (documentation), YAML (frontmatter metadata) + None (문서 기반 방법론)
 
 <!-- MANUAL ADDITIONS START -->
+
+## expo-dev-client Conditional Configuration
+
+- `app.config.ts`가 `app.json`의 plugins를 오버라이드하여 `expo-dev-client`를 조건부 포함
+- EAS 빌드 시 자동 설정되는 `EAS_BUILD_PROFILE` 환경변수로 분기
+- 로컬 빌드 (`expo run:ios/android`): `expo-dev-client` 플러그인 미포함
+- EAS development/development:device 빌드: `expo-dev-client` 플러그인 포함
+
 <!-- MANUAL ADDITIONS END -->

--- a/app.config.ts
+++ b/app.config.ts
@@ -1,0 +1,31 @@
+import { ConfigContext, ExpoConfig } from 'expo/config';
+
+const isEasDevBuild =
+  process.env.EAS_BUILD_PROFILE === 'development' ||
+  process.env.EAS_BUILD_PROFILE === 'development:device';
+
+export default ({ config }: ConfigContext): ExpoConfig => {
+  const plugins: ExpoConfig['plugins'] = [
+    'expo-router',
+    'expo-font',
+    'expo-updates',
+    'expo-sqlite',
+    [
+      'expo-build-properties',
+      {
+        android: {
+          kotlinVersion: '1.9.25',
+        },
+      },
+    ],
+  ];
+
+  if (isEasDevBuild) {
+    plugins.push('expo-dev-client');
+  }
+
+  return {
+    ...config,
+    plugins,
+  } as ExpoConfig;
+};

--- a/claude-specs/expo-dev-client.md
+++ b/claude-specs/expo-dev-client.md
@@ -1,0 +1,10 @@
+## Expo Dev Client를 조건별로 설정하기
+
+### Problem
+
+현재 프로젝트에는 expo-dev-client가 설치되어 있고, 별다른 설정이 되어있지 않습니다.
+따라서 원치않게 XCode로 dev build시, expo dev client용 앱이 설치되게 됩니다.
+다음 요구사항을 완성함으로써 이를 방지하고 싶습니다.
+
+- [x] xcode 등의 dev local build에서는 expo-dev-client를 사용하지 않아야 합니다.
+- [x] EAS의 development 빌드에서는 expo-dev-client를 사용하여 배포되어야 합니다.


### PR DESCRIPTION
## Summary
- `app.config.ts` 추가: `EAS_BUILD_PROFILE` 환경변수를 기반으로 `expo-dev-client` 플러그인을 조건부 포함
- 로컬 XCode 빌드 시 dev client 앱이 설치되는 문제 해결
- EAS development/development:device 빌드에서는 기존대로 expo-dev-client 정상 동작

## Test plan
- [x] `expo run:ios`로 로컬 빌드 시 dev client 앱이 설치되지 않는지 확인
- [ ] EAS development 프로필로 빌드 시 dev client가 정상 포함되는지 확인
- [ ] `npx expo config` 로 로컬 환경에서 plugins에 expo-dev-client가 없는지 확인
- [ ] `EAS_BUILD_PROFILE=development npx expo config` 로 plugins에 expo-dev-client가 포함되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)