### PR TITLE
Release/v0.3.0

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,5 +22,14 @@ module.exports = {
       version: 'detect',
     },
   },
-  ignorePatterns: ['node_modules/', 'dist/', 'build/', '.expo/', 'coverage/', 'sst.config.ts'],
+  ignorePatterns: [
+    'node_modules/',
+    'dist/',
+    'build/',
+    '.expo/',
+    'coverage/',
+    'sst.config.ts',
+    'ios/',
+    'android/',
+  ],
 };

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,16 @@ TypeScript 5.x: Follow standard conventions
    - 버전 자동 증가 및 타임스탬프 갱신
 3. 배치 파일은 작업 완료 후 삭제 가능
 
+## Release Tagging 컨벤션
+
+- `v{version}-iOS` — iOS 네이티브 바이너리 빌드 (App Store 제출)
+- `v{version}-web` — Web 정적 배포 (SST/CloudFront)
+- `v{version}-iOS-ota.N` — iOS OTA JS 번들 업데이트 (`eas update`, N은 1부터 순번)
+- runtimeVersion은 `appVersion` policy → `package.json`의 `version` 필드와 동일
+- 현재 운영 플랫폼: iOS + Web (Android 추후 추가 예정)
+- Android 출시 후 OTA가 양 플랫폼 동시 배포되면 `v{version}-ota.N`으로 전환
+- 상세 가이드: `docs/release-tagging.md`
+
 ## App Store 심사 제출
 
 - 가이드 문서: `docs/app-store-submission.md`

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,64 +1,11 @@
-import { Ionicons, MaterialIcons } from '@expo/vector-icons';
-import { Tabs } from 'expo-router';
-import { Icon, Label, NativeTabs } from 'expo-router/unstable-native-tabs';
+import NativeTabsLayout from '@/components/tabs/NativeTabsLayout';
+import OldLegacyTabs from '@/components/tabs/OldLegacyTabs';
 import { Platform } from 'react-native';
 
 export default function TabLayout() {
   if (Platform.OS === 'web') {
-    return (
-      <Tabs
-        screenOptions={{
-          tabBarActiveTintColor: '#0ea5e9',
-          tabBarInactiveTintColor: '#9ca3af',
-          headerStyle: {
-            backgroundColor: '#ffffff',
-          },
-          headerTitleStyle: {
-            fontWeight: '600',
-          },
-        }}
-      >
-        <Tabs.Screen
-          name="index"
-          options={{
-            title: '모아보기',
-            tabBarIcon: ({ color, size }) => (
-              <MaterialIcons name="church" size={size} color={color} />
-            ),
-          }}
-        />
-        <Tabs.Screen
-          name="search"
-          options={{
-            title: '검색',
-            tabBarIcon: ({ color, size }) => <Ionicons name="search" size={size} color={color} />,
-          }}
-        />
-        <Tabs.Screen
-          name="favorites"
-          options={{
-            title: '즐겨찾기',
-            tabBarIcon: ({ color, size }) => <Ionicons name="heart" size={size} color={color} />,
-          }}
-        />
-      </Tabs>
-    );
+    return <OldLegacyTabs />;
   }
 
-  return (
-    <NativeTabs>
-      <NativeTabs.Trigger name="index">
-        <Label>모아보기</Label>
-        <Icon sf="house.fill" drawable="custom_android_drawable" />
-      </NativeTabs.Trigger>
-      <NativeTabs.Trigger name="search">
-        <Label>검색</Label>
-        <Icon sf="magnifyingglass" drawable="custom_android_drawable" />
-      </NativeTabs.Trigger>
-      <NativeTabs.Trigger name="favorites">
-        <Label>즐겨찾기</Label>
-        <Icon sf="heart.fill" drawable="custom_android_drawable" />
-      </NativeTabs.Trigger>
-    </NativeTabs>
-  );
+  return <NativeTabsLayout />;
 }

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,3 +1,4 @@
+import { NavigationThemeProvider } from '@/components/navigation/NavigationThemeProvider';
 import NativeTabsLayout from '@/components/tabs/NativeTabsLayout';
 import OldLegacyTabs from '@/components/tabs/OldLegacyTabs';
 import { Platform } from 'react-native';
@@ -7,5 +8,9 @@ export default function TabLayout() {
     return <OldLegacyTabs />;
   }
 
-  return <NativeTabsLayout />;
+  return (
+    <NavigationThemeProvider>
+      <NativeTabsLayout />
+    </NavigationThemeProvider>
+  );
 }

--- a/app/(tabs)/favorites.tsx
+++ b/app/(tabs)/favorites.tsx
@@ -43,7 +43,7 @@ export default function FavoritesScreen() {
   }, []);
 
   return (
-    <SafeArea edges={['top']}>
+    <SafeArea>
       <CommonMetaHead title="즐겨찾기" description="북마크한 카톨릭 성인들을 모아보세요." />
       <View style={styles.container}>
         <FlatList

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -31,7 +31,7 @@ export default function HomeScreen() {
   useScrollToTop(listRef);
 
   return (
-    <SafeArea edges={['top']}>
+    <SafeArea>
       <CommonMetaHead title="모아보기" description="카톨릭 성인을 모아보세요." />
       <View style={styles.container}>
         <FlatList

--- a/app/(tabs)/search.tsx
+++ b/app/(tabs)/search.tsx
@@ -58,7 +58,7 @@ export default function SearchScreen() {
   }, [query]);
 
   return (
-    <SafeArea edges={['top']}>
+    <SafeArea>
       <CommonMetaHead
         title="검색"
         description="카톨릭 성인의 이름, 영어, 또는 라틴어 이름으로 검색하세요."

--- a/components/navigation/NavigationThemeProvider.tsx
+++ b/components/navigation/NavigationThemeProvider.tsx
@@ -1,0 +1,37 @@
+import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
+import { createContext, useContext } from 'react';
+import { ColorValue, DynamicColorIOS, Platform, useColorScheme } from 'react-native';
+
+const iosBackgroundColor = DynamicColorIOS({
+  dark: DarkTheme.colors.background,
+  light: DefaultTheme.colors.background,
+});
+
+type NavigationThemeContextValue = {
+  backgroundColor: ColorValue;
+};
+
+const NavigationThemeContext = createContext<NavigationThemeContextValue>({
+  backgroundColor: DefaultTheme.colors.background,
+});
+
+export const useNavigationTheme = () => useContext(NavigationThemeContext);
+
+export function NavigationThemeProvider({ children }: { children: React.ReactNode }) {
+  const colorScheme = useColorScheme();
+
+  const backgroundColor: ColorValue =
+    Platform.OS === 'ios'
+      ? iosBackgroundColor
+      : colorScheme === 'dark'
+        ? DarkTheme.colors.background
+        : DefaultTheme.colors.background;
+
+  return (
+    <NavigationThemeContext.Provider value={{ backgroundColor }}>
+      <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+        {children}
+      </ThemeProvider>
+    </NavigationThemeContext.Provider>
+  );
+}

--- a/components/navigation/NavigationThemeProvider.tsx
+++ b/components/navigation/NavigationThemeProvider.tsx
@@ -1,11 +1,8 @@
 import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
 import { createContext, useContext } from 'react';
-import { ColorValue, DynamicColorIOS, Platform, useColorScheme } from 'react-native';
+import { ColorValue, Platform, useColorScheme } from 'react-native';
 
-const iosBackgroundColor = DynamicColorIOS({
-  dark: DarkTheme.colors.background,
-  light: DefaultTheme.colors.background,
-});
+import { iosBackgroundColor } from './navigationColors';
 
 type NavigationThemeContextValue = {
   backgroundColor: ColorValue;

--- a/components/navigation/navigationColors.ts
+++ b/components/navigation/navigationColors.ts
@@ -1,0 +1,7 @@
+import { DarkTheme, DefaultTheme } from '@react-navigation/native';
+import { DynamicColorIOS } from 'react-native';
+
+export const iosBackgroundColor = DynamicColorIOS({
+  dark: DarkTheme.colors.background,
+  light: DefaultTheme.colors.background,
+});

--- a/components/navigation/navigationColors.web.ts
+++ b/components/navigation/navigationColors.web.ts
@@ -1,0 +1,3 @@
+import { DefaultTheme } from '@react-navigation/native';
+
+export const iosBackgroundColor = DefaultTheme.colors.background;

--- a/components/tabs/NativeTabsLayout.tsx
+++ b/components/tabs/NativeTabsLayout.tsx
@@ -1,20 +1,38 @@
+import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
 import { Icon, Label, NativeTabs } from 'expo-router/unstable-native-tabs';
+import { DynamicColorIOS, Platform, useColorScheme } from 'react-native';
+
+const iosBackgroundColor = DynamicColorIOS({
+  dark: DarkTheme.colors.background,
+  light: DefaultTheme.colors.background,
+});
 
 export default function NativeTabsLayout() {
+  const colorScheme = useColorScheme();
+
+  const backgroundColor =
+    Platform.OS === 'ios'
+      ? iosBackgroundColor
+      : colorScheme === 'dark'
+        ? DarkTheme.colors.background
+        : DefaultTheme.colors.background;
+
   return (
-    <NativeTabs>
-      <NativeTabs.Trigger name="index">
-        <Label>모아보기</Label>
-        <Icon sf="house.fill" drawable="custom_android_drawable" />
-      </NativeTabs.Trigger>
-      <NativeTabs.Trigger name="search">
-        <Label>검색</Label>
-        <Icon sf="magnifyingglass" drawable="custom_android_drawable" />
-      </NativeTabs.Trigger>
-      <NativeTabs.Trigger name="favorites">
-        <Label>즐겨찾기</Label>
-        <Icon sf="heart.fill" drawable="custom_android_drawable" />
-      </NativeTabs.Trigger>
-    </NativeTabs>
+    <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+      <NativeTabs backgroundColor={backgroundColor}>
+        <NativeTabs.Trigger name="index" options={{ backgroundColor }}>
+          <Label>모아보기</Label>
+          <Icon sf="house.fill" drawable="custom_android_drawable" />
+        </NativeTabs.Trigger>
+        <NativeTabs.Trigger name="search" options={{ backgroundColor }}>
+          <Label>검색</Label>
+          <Icon sf="magnifyingglass" drawable="custom_android_drawable" />
+        </NativeTabs.Trigger>
+        <NativeTabs.Trigger name="favorites" options={{ backgroundColor }}>
+          <Label>즐겨찾기</Label>
+          <Icon sf="heart.fill" drawable="custom_android_drawable" />
+        </NativeTabs.Trigger>
+      </NativeTabs>
+    </ThemeProvider>
   );
 }

--- a/components/tabs/NativeTabsLayout.tsx
+++ b/components/tabs/NativeTabsLayout.tsx
@@ -1,0 +1,20 @@
+import { Icon, Label, NativeTabs } from 'expo-router/unstable-native-tabs';
+
+export default function NativeTabsLayout() {
+  return (
+    <NativeTabs>
+      <NativeTabs.Trigger name="index">
+        <Label>모아보기</Label>
+        <Icon sf="house.fill" drawable="custom_android_drawable" />
+      </NativeTabs.Trigger>
+      <NativeTabs.Trigger name="search">
+        <Label>검색</Label>
+        <Icon sf="magnifyingglass" drawable="custom_android_drawable" />
+      </NativeTabs.Trigger>
+      <NativeTabs.Trigger name="favorites">
+        <Label>즐겨찾기</Label>
+        <Icon sf="heart.fill" drawable="custom_android_drawable" />
+      </NativeTabs.Trigger>
+    </NativeTabs>
+  );
+}

--- a/components/tabs/NativeTabsLayout.tsx
+++ b/components/tabs/NativeTabsLayout.tsx
@@ -1,38 +1,23 @@
-import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
+import { useNavigationTheme } from '@/components/navigation/NavigationThemeProvider';
 import { Icon, Label, NativeTabs } from 'expo-router/unstable-native-tabs';
-import { DynamicColorIOS, Platform, useColorScheme } from 'react-native';
-
-const iosBackgroundColor = DynamicColorIOS({
-  dark: DarkTheme.colors.background,
-  light: DefaultTheme.colors.background,
-});
 
 export default function NativeTabsLayout() {
-  const colorScheme = useColorScheme();
-
-  const backgroundColor =
-    Platform.OS === 'ios'
-      ? iosBackgroundColor
-      : colorScheme === 'dark'
-        ? DarkTheme.colors.background
-        : DefaultTheme.colors.background;
+  const { backgroundColor } = useNavigationTheme();
 
   return (
-    <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-      <NativeTabs backgroundColor={backgroundColor}>
-        <NativeTabs.Trigger name="index" options={{ backgroundColor }}>
-          <Label>모아보기</Label>
-          <Icon sf="house.fill" drawable="custom_android_drawable" />
-        </NativeTabs.Trigger>
-        <NativeTabs.Trigger name="search" options={{ backgroundColor }}>
-          <Label>검색</Label>
-          <Icon sf="magnifyingglass" drawable="custom_android_drawable" />
-        </NativeTabs.Trigger>
-        <NativeTabs.Trigger name="favorites" options={{ backgroundColor }}>
-          <Label>즐겨찾기</Label>
-          <Icon sf="heart.fill" drawable="custom_android_drawable" />
-        </NativeTabs.Trigger>
-      </NativeTabs>
-    </ThemeProvider>
+    <NativeTabs backgroundColor={backgroundColor}>
+      <NativeTabs.Trigger name="index" options={{ backgroundColor }}>
+        <Label>모아보기</Label>
+        <Icon sf="house.fill" drawable="custom_android_drawable" />
+      </NativeTabs.Trigger>
+      <NativeTabs.Trigger name="search" options={{ backgroundColor }}>
+        <Label>검색</Label>
+        <Icon sf="magnifyingglass" drawable="custom_android_drawable" />
+      </NativeTabs.Trigger>
+      <NativeTabs.Trigger name="favorites" options={{ backgroundColor }}>
+        <Label>즐겨찾기</Label>
+        <Icon sf="heart.fill" drawable="custom_android_drawable" />
+      </NativeTabs.Trigger>
+    </NativeTabs>
   );
 }

--- a/components/tabs/OldLegacyTabs.tsx
+++ b/components/tabs/OldLegacyTabs.tsx
@@ -1,0 +1,43 @@
+import { Ionicons, MaterialIcons } from '@expo/vector-icons';
+import { Tabs } from 'expo-router';
+
+export default function OldLegacyTabs() {
+  return (
+    <Tabs
+      screenOptions={{
+        tabBarActiveTintColor: '#0ea5e9',
+        tabBarInactiveTintColor: '#9ca3af',
+        headerStyle: {
+          backgroundColor: '#ffffff',
+        },
+        headerTitleStyle: {
+          fontWeight: '600',
+        },
+      }}
+    >
+      <Tabs.Screen
+        name="index"
+        options={{
+          title: '모아보기',
+          tabBarIcon: ({ color, size }) => (
+            <MaterialIcons name="church" size={size} color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="search"
+        options={{
+          title: '검색',
+          tabBarIcon: ({ color, size }) => <Ionicons name="search" size={size} color={color} />,
+        }}
+      />
+      <Tabs.Screen
+        name="favorites"
+        options={{
+          title: '즐겨찾기',
+          tabBarIcon: ({ color, size }) => <Ionicons name="heart" size={size} color={color} />,
+        }}
+      />
+    </Tabs>
+  );
+}

--- a/components/ui/SafeArea.tsx
+++ b/components/ui/SafeArea.tsx
@@ -1,23 +1,25 @@
-import { StyleProp, ViewStyle } from 'react-native';
-import { Edge, SafeAreaView } from 'react-native-safe-area-context';
+import { useMemo } from 'react';
+import { StyleProp, View, ViewStyle } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 export const ESTIMATED_BOTTOM_SPACE_FOR_TAB_BAR = 150;
 
 export const SafeArea = ({
   children,
-  edges = ['top'],
   withBottomTabBar = false,
   style,
 }: {
   children: React.ReactNode;
-  edges?: Edge[];
   withBottomTabBar?: boolean;
   style?: StyleProp<ViewStyle>;
 }) => {
-  const bottomSpace = withBottomTabBar ? ESTIMATED_BOTTOM_SPACE_FOR_TAB_BAR : 0;
-  return (
-    <SafeAreaView edges={edges} style={[style, { flex: 1, paddingBottom: bottomSpace }]}>
-      {children}
-    </SafeAreaView>
-  );
+  const insets = useSafeAreaInsets();
+  const edgeStyles: StyleProp<ViewStyle> = useMemo(() => {
+    const styles = {
+      paddingTop: insets.top,
+      paddingBottom: withBottomTabBar ? ESTIMATED_BOTTOM_SPACE_FOR_TAB_BAR : 0,
+    };
+    return styles;
+  }, [insets, withBottomTabBar]);
+  return <View style={[style, { flex: 1, backgroundColor: 'white' }, edgeStyles]}>{children}</View>;
 };

--- a/docs/release-tagging.md
+++ b/docs/release-tagging.md
@@ -1,0 +1,56 @@
+# Release Tagging 가이드
+
+## 태그 컨벤션
+
+| 태그 형식              | 의미                                        | 시점                                                       |
+| ---------------------- | ------------------------------------------- | ---------------------------------------------------------- |
+| `v{version}-iOS`       | iOS 네이티브 바이너리 빌드 (App Store 제출) | `eas build --platform ios --profile production` 완료 후    |
+| `v{version}-web`       | Web 정적 배포 (SST/CloudFront)              | `sst deploy --stage production` 완료 후                    |
+| `v{version}-iOS-ota.N` | iOS OTA JS 번들 업데이트                    | `eas update --channel production` 완료 후 (N은 1부터 순번) |
+
+## runtimeVersion 정책
+
+`app.config.ts`에서 `runtimeVersion: { policy: 'appVersion' }`으로 설정되어 있어, runtimeVersion은 `package.json`의 `version` 필드와 동일하게 자동 결정됩니다.
+
+```
+package.json version: "0.3.0"
+  → runtimeVersion: "0.3.0"
+  → 이 runtimeVersion을 가진 바이너리에만 OTA 적용
+```
+
+**OTA 업데이트(`eas update`)는 동일한 runtimeVersion의 바이너리에만 전달됩니다.** 네이티브 코드 변경이 있으면 version을 올리고 새 바이너리 빌드가 필요합니다.
+
+## 현재 운영 플랫폼
+
+- **iOS** (App Store) — 운영 중
+- **Web** (SST/CloudFront) — 운영 중
+- **Android** — 추후 운영 예정
+
+iOS만 운영 중이므로 `eas update`는 사실상 iOS 전용입니다. 태그에 `-iOS`를 명시하여 플랫폼을 구분합니다.
+
+## 릴리즈 플로우 예시 (v0.3.0)
+
+```bash
+# 1. iOS 바이너리 빌드 → App Store 제출
+eas build --platform ios --profile production
+git tag v0.3.0-iOS && git push origin v0.3.0-iOS
+
+# 2. Web 배포
+sst deploy --stage production   # 또는 GitHub Actions workflow_dispatch
+git tag v0.3.0-web && git push origin v0.3.0-web
+
+# 3. JS-only 변경 사항 OTA 배포 (네이티브 변경 없을 때)
+eas update --channel production --message "fix: dark mode tab bar"
+git tag v0.3.0-iOS-ota.1 && git push origin v0.3.0-iOS-ota.1
+
+# 4. 추가 OTA가 있으면 순번 증가
+git tag v0.3.0-iOS-ota.2 && git push origin v0.3.0-iOS-ota.2
+```
+
+## Android 출시 이후
+
+`eas update`가 iOS + Android를 동시에 타겟하게 되면, OTA 태그를 플랫폼 구분 없이 변경합니다:
+
+```
+v{version}-iOS-ota.N  →  v{version}-ota.N
+```

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.0",
+  "version": "0.3.0",
   "name": "catholic-saints-search",
   "description": "카톨릭 성인 검색 앱",
   "main": "expo-router/entry",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0",
+  "version": "0.4.0",
   "name": "catholic-saints-search",
   "description": "카톨릭 성인 검색 앱",
   "main": "expo-router/entry",


### PR DESCRIPTION
## v0.3.0

### Changes
- feat: update SafeArea to use insets-based padding for native tabs
- fix: add backgroundColor to NativeTabs for dark mode tab bar flash
- fix: split DynamicColorIOS into platform-specific constants to prevent web error
- refactor: extract tab layouts into OldLegacyTabs and NativeTabsLayout components
- refactor: extract NavigationThemeProvider and apply to tabs layout
- chore: update eslint ignore

### Docs
- docs: add release tagging convention (`docs/release-tagging.md`, `CLAUDE.md`)

---

### Release Tag Plan (after merge + `eas update`)
```
git tag v0.3.0-iOS-ota.1
git push origin v0.3.0-iOS-ota.1
```

> runtimeVersion = appVersion policy → `package.json version: 0.3.0`  
> OTA는 runtimeVersion `0.3.0` 바이너리(iOS)에만 적용됨